### PR TITLE
Add support for C++ style comment within arrays

### DIFF
--- a/grammars/dts.cson
+++ b/grammars/dts.cson
@@ -103,6 +103,11 @@ repository:
             name: 'entity.name.function.preprocessor.dts'
           }
           {
+            begin: '//'
+            end: '\\n'
+            name: 'comment.line.double-slash.dts'
+          }
+          {
             begin: '/\\*'
             beginCaptures:
               '0':


### PR DESCRIPTION
C++ style comment within integer arrays are convenient in multi line lists.  